### PR TITLE
listen for click on the checkbox image too

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -565,6 +565,7 @@ listen("#frameprev", "click", frames.decrementFrame);
 listen("#framenext", "click", frames.incrementFrame);
 listen("#framelast", "click", frames.goToLastFrame);
 listen("#doonionskin", "change", state.toggleOnionskin);
+listen(".onionskin > i", "click", state.toggleOnionskin);
 listen("#animate", "click", evt => ui.toggleToolbar(evt.currentTarget.id));
 listen("#animateplay", "click", animation.play);
 listen("#framerate", "change", evt => (state.fps = evt.currentTarget.value));


### PR DESCRIPTION
Fixes #82 

It turns out that clicking the label would work, but because we hide the checkbox in order to style it with Font Awesome icons, that clicks on the checkbox image weren't triggering a change. Now toggling the checkbox when the images are clicked as well.