### PR TITLE
removed use of Firefox-only event property

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -595,11 +595,12 @@ listen("#animateplay", "click", animation.play);
 listen("#framerate", "change", evt => (state.fps = evt.currentTarget.value));
 listen(".timeline-label", "click", timeline.toggleTimeline);
 listen("#shortcuts", "click", ui.showShortcuts);
-listen(".timeline-frames", "click", evt =>
+listen(".timeline-frames", "click", evt => {
   frames.goToFrame(
     ui.currentFrame(),
-    timeline.frameForThumbnail(evt.originalTarget)
-  )
+    timeline.frameForThumbnail(evt.target)
+  );
+  }
 );
 // File Events
 listen(window, "unload", saveLocal);

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -14,8 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import ui from "./ui.js";
-import {$, $$, html} from "./dom.js";
-
+import { $, $$, html } from "./dom.js";
 
 function frameToThumbnail(frame) {
   return ui.frameToImage(frame, 0, 0, WIDTH, HEIGHT, 64);
@@ -31,7 +30,6 @@ function thumbnailForFrame(frame) {
 }
 
 function frameForThumbnail(thumb) {
-  // FIXME: #81 Timeline Dependencies
   return $(`#${thumb.id.split("-")[0]}`);
 }
 
@@ -74,11 +72,23 @@ function toggleTimeline() {
   document.body.classList.toggle("notimeline");
 }
 
-function selectThumbnail(frame){
-    $$('.canvas-frame.selected').forEach(thumb => thumb.classList.remove("selected"));
-    let nextThumb = thumbnailForFrame(frame);
-    nextThumb.classList.add("selected");
-    nextThumb.scrollIntoView();
+function selectThumbnail(frame) {
+  $$(".canvas-frame.selected").forEach(thumb =>
+    thumb.classList.remove("selected")
+  );
+  let nextThumb = thumbnailForFrame(frame);
+  nextThumb.classList.add("selected");
+  nextThumb.scrollIntoView();
 }
 
-export { frameToThumbnail, frameForThumbnail, thumbnailForFrame, makeThumbnails, updateThumbnail, addThumbnail, removeThumbnail, selectThumbnail, toggleTimeline }
+export {
+  frameToThumbnail,
+  frameForThumbnail,
+  thumbnailForFrame,
+  makeThumbnails,
+  updateThumbnail,
+  addThumbnail,
+  removeThumbnail,
+  selectThumbnail,
+  toggleTimeline,
+};

--- a/js/ui.js
+++ b/js/ui.js
@@ -64,11 +64,11 @@ const colorpicker = new KellyColorPicker({
 });
 
 function setPaletteHandler(evt) {
-  const sel = evt.target || evt.originalTarget;
+  const sel = evt.target;
   state.palette = sel.value;
   sel.blur();
 }
-setPaletteHandler({ originalTarget: colorpaletteselect });
+setPaletteHandler({ target: colorpaletteselect });
 
 function compareColorButton(button, color) {
   switch (color[0]) {


### PR DESCRIPTION
Fixes #100 

Not sure why I was using a Firefox-only property of event, and this bugs me because I remember there was a problem where `evt.target` didn't work. But I'm using `evt.target` now and things seem to be working OK, so I'll deal with it when something breaks.