### PR TITLE
don't break when clicking between frames in timeline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -466,6 +466,7 @@ dialog .close {
   left: 6px;
   padding: 2px;
   font-family: sans-serif;
+  pointer-events: none;
 }
 
 /* Moving  Mess popup styles here */

--- a/js/script.js
+++ b/js/script.js
@@ -28,10 +28,9 @@ import * as timeline from "./timeline.js";
 import GIF from "../lib/gif.js";
 import JSZip from "../lib/jszip.min.js";
 
-if('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('./js/sw.js');
-};
-
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("./js/sw.js");
+}
 
 // Wrap `dom.listen` and `dom.addShortcuts` so that events don't trigger during animation playback
 
@@ -596,12 +595,11 @@ listen("#framerate", "change", evt => (state.fps = evt.currentTarget.value));
 listen(".timeline-label", "click", timeline.toggleTimeline);
 listen("#shortcuts", "click", ui.showShortcuts);
 listen(".timeline-frames", "click", evt => {
-  frames.goToFrame(
-    ui.currentFrame(),
-    timeline.frameForThumbnail(evt.target)
-  );
+  if (!evt.target.matches(".canvas-frame")) {
+    return;
   }
-);
+  frames.goToFrame(ui.currentFrame(), timeline.frameForThumbnail(evt.target));
+});
 // File Events
 listen(window, "unload", saveLocal);
 listen(window, "load", restoreLocal);


### PR DESCRIPTION
Found a few more edge-case bugs (literally clicking on the edge of a frame triggered a bug).